### PR TITLE
custom relative assets folder

### DIFF
--- a/lib/markdown-img-paste.coffee
+++ b/lib/markdown-img-paste.coffee
@@ -37,17 +37,16 @@ module.exports =
 
         #Sets up image assets folder
         curDirectory = dirname(cursor.getPath())
-        fullname = join(curDirectory, filename)
 
         #Checks if assets folder is to be used
         if atom.config.get 'markdown-img-paste.use_assets_folder'
           #Finds assets directory path
-          assetsDirectory = join(curDirectory, "assets") + "/"
+          assetsDirectory = join(curDirectory,atom.config.get 'markdown-img-paste.assets_folder')
 
           #Creates directory if necessary
           if !fs.existsSync assetsDirectory
             fs.mkdirSync assetsDirectory
-          
+
 
           #Sets full img path
           fullname = join(assetsDirectory, filename)
@@ -86,9 +85,9 @@ module.exports =
             mdtext = '![]('
 
             if atom.config.get 'markdown-img-paste.use_assets_folder'
-                mdtext += 'assets/'
-            
-            mdtext += filename + ')' 
+                mdtext += atom.config.get 'markdown-img-paste.assets_folder' #'assets/'
+
+            mdtext += filename + ')'
 
             paste_mdtext cursor, mdtext
 

--- a/lib/markdown-img-paste.coffee
+++ b/lib/markdown-img-paste.coffee
@@ -37,16 +37,20 @@ module.exports =
 
         #Sets up image assets folder
         curDirectory = dirname(cursor.getPath())
+        if atom.config.get 'markdown-img-paste.use_project_assets_folder'
+          projectsDirectories = atom.project.getPaths()
+          for index in projectsDirectories
+            if curDirectory.indexOf(index) >= 0
+              curDirectory = index
 
         #Checks if assets folder is to be used
         if atom.config.get 'markdown-img-paste.use_assets_folder'
           #Finds assets directory path
-          assetsDirectory = join(curDirectory,atom.config.get 'markdown-img-paste.assets_folder')
+          assetsDirectory = join(curDirectory,atom.config.get 'markdown-img-paste.zAassets_folder')
 
           #Creates directory if necessary
           if !fs.existsSync assetsDirectory
-            fs.mkdirSync assetsDirectory
-
+            mkdirsSync assetsDirectory
 
           #Sets full img path
           fullname = join(assetsDirectory, filename)
@@ -85,7 +89,7 @@ module.exports =
             mdtext = '![]('
 
             if atom.config.get 'markdown-img-paste.use_assets_folder'
-                mdtext += atom.config.get 'markdown-img-paste.assets_folder' #'assets/'
+                mdtext += atom.config.get 'markdown-img-paste.zAassets_folder'
 
             mdtext += filename + ')'
 
@@ -150,6 +154,27 @@ paste_mdtext = (cursor, mdtext) ->
     position = cursor.getCursorBufferPosition()
     position.column = position.column - mdtext.length + 2
     cursor.setCursorBufferPosition position
+
+mkdirsSync = (dirpath, mode) ->
+  try
+    if !fs.existsSync(dirpath)
+      pathtmp = undefined
+      dirpath.split(/[/\\]/).forEach (dirname) ->
+        #这里指用/ 或\ 都可以分隔目录  如  linux的/usr/local/services   和windows的 d:\temp\aaaa
+        if pathtmp
+          pathtmp = join(pathtmp, dirname)
+        else
+          pathtmp = dirname
+        if !fs.existsSync(pathtmp)
+          if !fs.mkdirSync(pathtmp, mode)
+            return false
+        return
+    return true
+  catch e
+    console.console.error 'create director fail! path=' + dirpath + ' errorMsg:' + e
+    return false
+  return
+
 
 
 Date.prototype.format = ->

--- a/package.json
+++ b/package.json
@@ -31,8 +31,14 @@
     "use_assets_folder": {
       "type": "boolean",
       "default": true,
-      "title": "Is Save images in local assets folder",
-      "description": ""
+      "title": "Save images in local relative assets folder",
+      "description": "save images to ./'assets folder relative path'"
+    },
+    "use_project_assets_folder": {
+      "type": "boolean",
+      "default": true,
+      "title": "Save images to project folder",
+      "description": "save images to project/'assets folder relative path'(recommend check when use jekyll)"
     },
     "upload_to_mssm": {
       "type": "boolean",
@@ -46,12 +52,12 @@
       "title": "Use qiniu for image link",
       "description": ""
     },
-    "assets_folder": {
+    "zAassets_folder": {
       "type": "string",
       "default": "assets/images/",
-      "title": "Assets folder path",
+      "title": "Assets folder relative path",
       "description": ""
-    },    
+    },
     "zAccessKey": {
       "type": "string",
       "default": "",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "use_assets_folder": {
       "type": "boolean",
       "default": true,
-      "title": "Save images in assets folder",
+      "title": "Is Save images in local assets folder",
       "description": ""
     },
     "upload_to_mssm": {
@@ -46,6 +46,12 @@
       "title": "Use qiniu for image link",
       "description": ""
     },
+    "assets_folder": {
+      "type": "string",
+      "default": "assets/images/",
+      "title": "Assets folder path",
+      "description": ""
+    },    
     "zAccessKey": {
       "type": "string",
       "default": "",


### PR DESCRIPTION
# update Features
* add option: custom relative aseets folder  eg: ./assets/images
* add option: save to project relative folder eg: assets/images

and this update may resolve issue #6 

# TODO?
* support  `{year}` `{month}` in custom path, (like `markdown-writer` did)
![image](https://cloud.githubusercontent.com/assets/8625829/24290580/73bdc248-10c0-11e7-8d65-9331fb9d838a.png)
